### PR TITLE
golangci-lint: include exported rule for real

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,12 @@ linters:
     - thelper
     - unconvert
 
+issues:
+  include:
+    - EXC0012
+    - EXC0013
+    - EXC0014
+    - EXC0015
 linters-settings:
   revive:
     # Maximum number of open files at the same time.


### PR DESCRIPTION
Some rules will be plainly ignored due to the exclusion list.

See https://golangci-lint.run/usage/configuration/#issues-configuration and https://golangci-lint.run/usage/false-positives/#exc0012 and https://github.com/golangci/golangci-lint/issues/1937#issuecomment-1278151540